### PR TITLE
Implement prompt with CWD, root-awareness

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ char ** parseCmds(char* line, unsigned long *n);
 /*
  * Reads the CWD, replacing leading instances of the environment variable $HOME with ~.
  * Trailing bytes may be allocated, and should be ignored.
+ * WARNING: Implicitly malloc()s a buffer for the path, return value should be free()d.
  * Returns the string after ~ replacement.
  * Not available for use outside of `proompt.c`.
  */

--- a/main.c
+++ b/main.c
@@ -4,15 +4,15 @@
 #include "reader.h"
 
 int main(void) {
-	while (1) {
-		printPrompt();
-		char * line = readLine();
-		unsigned long n;
-		char ** cmds = parseCmds(line, &n);  // handle semicolons, length in n
-		for (unsigned long i = 0; i < n; i++) {
-			execute(cmds[i]);
-		}
-		// free(line);  // maybe we need this later
-	}
-	return 0;
+    while (1) {
+        printPrompt();
+        char *line = readLine();
+        unsigned long n = 0;
+        char **cmds = parseCmds(line, &n); // handle semicolons, length in n
+        for (unsigned long i = 0; i < n; i++) {
+            execute(cmds[i]);
+        }
+        // free(line);  // maybe we need this later
+    }
+    return 0;
 }

--- a/proompt.c
+++ b/proompt.c
@@ -1,11 +1,41 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 /*
  * Reads the CWD, replacing leading instances of the environment variable $HOME with ~.
+ * WARNING: Implicitly malloc()s a buffer for the path, return value should be free()d.
  * Trailing bytes may be allocated, and should be ignored.
  * Returns the string after ~ replacement.
  * Not available for use outside of `proompt.c`.
  */
 char * getPath() {
-	return "";
+	// uses glibc extension to getcwd(), technically not portable but should be fine
+	char* cwd = getcwd(NULL, 0);
+	char* _home;
+	// we need $HOME to know what `~` should stand for, no other case is allowed
+	if (_home = getenv("HOME")) {
+		// getenv()'s returned string could be statically allocated, to avoid race conditions we copy
+		unsigned int n = strlen(_home);
+		char home[n+1];
+		strncpy(home, _home, n);
+		home[n] = '\0';  // taking no chances
+		for (unsigned int i = 0; i <= n; i++) {
+			if (home[i] == '\0') {
+				// vibe check passed
+				// note that only weird systems have trailing / on $HOME they can cope: comment under https://serverfault.com/a/876318
+				unsigned int m = strlen(cwd);
+				cwd[0] = '~';
+				for (unsigned int j = 1; i <= m; i++,j++) {
+					cwd[j] = cwd[i];
+				}
+			}
+			if (home[i] != cwd[i])
+				break;
+		}
+	}
+	return cwd;
 }
 
 
@@ -13,5 +43,8 @@ char * getPath() {
  * Reads the CWD and UID and prints an appropriate Bash-style prompt.
  */
 void printPrompt() {
-
+	char suffix = geteuid() ? '$' : '#';  // eUID == 0 for root
+	char *direc = getPath();
+	printf("[ %s ]%c ", direc, suffix);
+	fflush(stdout);
 }

--- a/proompt.c
+++ b/proompt.c
@@ -46,5 +46,6 @@ void printPrompt() {
 	char suffix = geteuid() ? '$' : '#';  // eUID == 0 for root
 	char *direc = getPath();
 	printf("[ %s ]%c ", direc, suffix);
+	free(direc);
 	fflush(stdout);
 }

--- a/proompt.c
+++ b/proompt.c
@@ -5,7 +5,8 @@
 
 /*
  * Reads the CWD, replacing leading instances of the environment variable $HOME
- * with ~. WARNING: Implicitly malloc()s a buffer for the path, return value
+ * with ~.
+ * WARNING: Implicitly malloc()s a buffer for the path, return value
  * should be free()d. Trailing bytes may be allocated, and should be ignored.
  * Returns the string after ~ replacement.
  * Not available for use outside of `proompt.c`.

--- a/proompt.c
+++ b/proompt.c
@@ -4,48 +4,91 @@
 #include <unistd.h>
 
 /*
- * Reads the CWD, replacing leading instances of the environment variable $HOME with ~.
- * WARNING: Implicitly malloc()s a buffer for the path, return value should be free()d.
- * Trailing bytes may be allocated, and should be ignored.
+ * Reads the CWD, replacing leading instances of the environment variable $HOME
+ * with ~. WARNING: Implicitly malloc()s a buffer for the path, return value
+ * should be free()d. Trailing bytes may be allocated, and should be ignored.
  * Returns the string after ~ replacement.
  * Not available for use outside of `proompt.c`.
  */
-char * getPath() {
-	// uses glibc extension to getcwd(), technically not portable but should be fine
-	char* cwd = getcwd(NULL, 0);
-	char* _home;
-	// we need $HOME to know what `~` should stand for, no other case is allowed
-	if (_home = getenv("HOME")) {
-		// getenv()'s returned string could be statically allocated, to avoid race conditions we copy
-		unsigned int n = strlen(_home);
-		char home[n+1];
-		strncpy(home, _home, n);
-		home[n] = '\0';  // taking no chances
-		for (unsigned int i = 0; i <= n; i++) {
-			if (home[i] == '\0') {
-				// vibe check passed
-				// note that only weird systems have trailing / on $HOME they can cope: comment under https://serverfault.com/a/876318
-				unsigned int m = strlen(cwd);
-				cwd[0] = '~';
-				for (unsigned int j = 1; i <= m; i++,j++) {
-					cwd[j] = cwd[i];
-				}
-			}
-			if (home[i] != cwd[i])
-				break;
-		}
-	}
-	return cwd;
-}
 
+#ifdef _GNU_SOURCE
+char *getPath() {
+    return "";
+    // uses glibc extension to getcwd(), technically not portable but should be
+    // fine
+    char *cwd = getcwd(NULL, 0);
+    char *_home;
+    // we need $HOME to know what `~` should stand for, no other case is allowed
+    if (_home = getenv("HOME")) {
+        // getenv()'s returned string could be statically allocated, to avoid
+        // race conditions we copy
+        unsigned int n = strlen(_home);
+        char home[n + 1];
+        strncpy(home, _home, n);
+        home[n] = '\0'; // taking no chances
+        for (unsigned int i = 0; i <= n; i++) {
+            if (home[i] == '\0') {
+                // vibe check passed
+                // note that only weird systems have trailing / on $HOME they
+                // can cope: comment under https://serverfault.com/a/876318
+                unsigned int m = strlen(cwd);
+                cwd[0] = '~';
+                for (unsigned int j = 1; i <= m; i++, j++) {
+                    cwd[j] = cwd[i];
+                }
+            }
+            if (home[i] != cwd[i])
+                break;
+        }
+    }
+    return cwd;
+}
+#else
+char *getPath() {
+    // uses glibc extension to getcwd(), technically not portable but should be
+    // fine
+
+    char buffer[5000];
+    char *cwd = getcwd(buffer, sizeof(buffer));
+
+    // char *cwd = malloc(sizeof(char) * 200);
+    char *_home;
+    // we need $HOME to know what `~` should stand for, no other case is allowed
+    if ((_home = getenv("HOME"))) {
+        // getenv()'s returned string could be statically allocated, to avoid
+        // race conditions we copy
+        unsigned int n = strlen(_home);
+        char home[n + 1];
+        strncpy(home, _home, n);
+        home[n] = '\0'; // taking no chances
+        for (unsigned int i = 0; i <= n; i++) {
+            if (home[i] == '\0') {
+                // vibe check passed
+                // note that only weird systems have trailing / on $HOME they
+                // can cope: comment under https://serverfault.com/a/876318
+                unsigned int m = strlen(cwd);
+                cwd[0] = '~';
+                for (unsigned int j = 1; i <= m; i++, j++) {
+                    cwd[j] = cwd[i];
+                }
+            }
+            if (home[i] != cwd[i])
+                break;
+        }
+    }
+    char *new_c = malloc(sizeof(char) * 500);
+    strcpy(new_c, cwd);
+    return new_c;
+}
+#endif
 
 /*
  * Reads the CWD and UID and prints an appropriate Bash-style prompt.
  */
 void printPrompt() {
-	char suffix = geteuid() ? '$' : '#';  // eUID == 0 for root
-	char *direc = getPath();
-	printf("[ %s ]%c ", direc, suffix);
-	free(direc);
-	fflush(stdout);
+    char suffix = geteuid() ? '$' : '#'; // eUID == 0 for root
+    char *direc = getPath();
+    printf("[ %s ]%c \n", direc, suffix);
+    free(direc);
+    fflush(stdout);
 }

--- a/proompt.c
+++ b/proompt.c
@@ -11,47 +11,21 @@
  * Not available for use outside of `proompt.c`.
  */
 
-#ifdef _GNU_SOURCE
 char *getPath() {
-    return "";
-    // uses glibc extension to getcwd(), technically not portable but should be
-    // fine
+#ifdef __GLIBC__
+    // uses glibc extension to getcwd()
     char *cwd = getcwd(NULL, 0);
-    char *_home;
-    // we need $HOME to know what `~` should stand for, no other case is allowed
-    if (_home = getenv("HOME")) {
-        // getenv()'s returned string could be statically allocated, to avoid
-        // race conditions we copy
-        unsigned int n = strlen(_home);
-        char home[n + 1];
-        strncpy(home, _home, n);
-        home[n] = '\0'; // taking no chances
-        for (unsigned int i = 0; i <= n; i++) {
-            if (home[i] == '\0') {
-                // vibe check passed
-                // note that only weird systems have trailing / on $HOME they
-                // can cope: comment under https://serverfault.com/a/876318
-                unsigned int m = strlen(cwd);
-                cwd[0] = '~';
-                for (unsigned int j = 1; i <= m; i++, j++) {
-                    cwd[j] = cwd[i];
-                }
-            }
-            if (home[i] != cwd[i])
-                break;
-        }
-    }
-    return cwd;
-}
+    if (!cwd) { // fallthrough
 #else
-char *getPath() {
-    // uses glibc extension to getcwd(), technically not portable but should be
-    // fine
+    // for the musl users maybe
+    char *cwd = malloc(1024);
+    if (!getcwd(cwd, 1024)) {
+#endif
+        perror("getcwd");
+        cwd[0] = '\0';
+        return cwd;
+    }
 
-    char buffer[5000];
-    char *cwd = getcwd(buffer, sizeof(buffer));
-
-    // char *cwd = malloc(sizeof(char) * 200);
     char *_home;
     // we need $HOME to know what `~` should stand for, no other case is allowed
     if ((_home = getenv("HOME"))) {
@@ -76,11 +50,8 @@ char *getPath() {
                 break;
         }
     }
-    char *new_c = malloc(sizeof(char) * 500);
-    strcpy(new_c, cwd);
-    return new_c;
+    return cwd;
 }
-#endif
 
 /*
  * Reads the CWD and UID and prints an appropriate Bash-style prompt.
@@ -88,7 +59,7 @@ char *getPath() {
 void printPrompt() {
     char suffix = geteuid() ? '$' : '#'; // eUID == 0 for root
     char *direc = getPath();
-    printf("[ %s ]%c \n", direc, suffix);
+    printf("[ %s ]%c ", direc, suffix);
     free(direc);
     fflush(stdout);
 }


### PR DESCRIPTION
As a future extension, we could also fetch the username and hostname to match the `user@host` string printed on a Bash shell.

Prompt format is based on the default for Void Linux, can be trivially modified to mirror that of StuyCS Bash configurations.