### PR TITLE
Implement better reader with filtered whitespace output

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -1,0 +1,13 @@
+echo "hello world"
+cowsay "sigma"
+cowsay -f vader "hello world"
+echo "hello world" | cowsay -f vader
+echo "hello world" > sigma.txt
+cat sigma.txt
+echo "sigma skibidi" > sigma.txt
+cat < sigma.txt
+cat < sigma.txt | cowsay -f vader  > vader.txt
+ls > ls.txt
+ls
+cd ..
+ls

--- a/executor.c
+++ b/executor.c
@@ -34,7 +34,9 @@ void execute(char *command) {
     // TODO MAKE DYNAMIC
     char *args[16];
     parse_args(command, args);
-    if (!strcmp(args[0], "cd")) {
+    if (args[0] == NULL || args[0][0] == '\0')
+        return;
+    else if (!strcmp(args[0], "cd")) {
         char *path = args[1]; // in worst case is NULL
         if (!path)
             path = getenv("HOME");
@@ -42,18 +44,19 @@ void execute(char *command) {
             chdir(path);
     } else if (!strcmp(args[0], "exit")) {
         exit(0);
-    }
-    pid_t p;
-    p = fork();
-    if (p < 0) {
-        perror("fork");
-        return;
-    } else if (p == 0) {
-        execvp(args[0], args);
-        perror(args[0]);
-        exit(errno);
     } else {
-        int status;
-        int exit_pid = wait(&status);
+        pid_t p;
+        p = fork();
+        if (p < 0) {
+            perror("fork");
+            return;
+        } else if (p == 0) {
+            execvp(args[0], args);
+            perror(args[0]);
+            exit(errno);
+        } else {
+            int status;
+            int exit_pid = wait(&status);
+        }
     }
 }

--- a/main.c
+++ b/main.c
@@ -12,14 +12,11 @@ int main(void) {
         char *line = readLine();
         unsigned long n = 0;
         char **cmds = parseCmds(line, &n); // handle semicolons, length in n
-        char *e = "exit";
-        if (strcmp(cmds[0], e) == 0) {
-            exit(0);
-        }
         for (unsigned long i = 0; i < n; i++) {
             execute(cmds[i]);
         }
-        // free(line);  // maybe we need this later
+        free(line);
+        free(cmds);
     }
     return 0;
 }

--- a/reader.c
+++ b/reader.c
@@ -15,7 +15,7 @@ char *readLine() {
         perror("malloc");
         exit(errno);
     }
-    int buf;
+    int buf, last = 0;
     char endLoop = 0;
     while ((buf = fgetc(stdin)) != EOF) {
         switch (buf) {
@@ -27,9 +27,18 @@ char *readLine() {
         case '\r':
         case '\n':
             endLoop = 1;
+            // roll back trailing whitespace
+            while (ret[--i] == ' ' || ret[i] == '\t')
+                ;
+            i++;
             buf = '\0';
         // fallthrough
+        case ' ':
+            if (buf == ' ' && last == ' ')
+                continue;
+        // fallthrough
         default:
+            last = buf;
             if (i >= size) {
                 size *= 2;
                 if (!(ret = realloc(ret, size * sizeof(char)))) {


### PR DESCRIPTION
Implements a dynamically sized buffer for the input reader, along with a filter to remove redundant whitespace.
Fixes bugs spotted as a result of this more aggressive input modification, such as the response when a command is empty, along with the free()ing of malloc()ed memory.